### PR TITLE
Set refresh cookie path and add CSRF checks

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -16,6 +16,7 @@ public class AuthController(
     IConfiguration configuration) : ControllerBase
 {
     private const string RefreshCookieName = "refreshToken";
+    private const string RefreshCookiePath = "/api/auth";
 
     private readonly int _refreshTokenDays = int.TryParse(configuration["Jwt:RefreshTokenDays"], out var days)
         ? days
@@ -152,7 +153,10 @@ public class AuthController(
             }
         }
 
-        Response.Cookies.Delete(RefreshCookieName);
+        Response.Cookies.Delete(RefreshCookieName, new CookieOptions
+        {
+            Path = RefreshCookiePath
+        });
         return NoContent();
     }
 
@@ -198,9 +202,10 @@ public class AuthController(
         var cookieOptions = new CookieOptions
         {
             HttpOnly = true,
-            Secure = Request.IsHttps,
-            SameSite = SameSiteMode.Lax,
-            Expires = expiresAt
+            Secure = true,
+            SameSite = SameSiteMode.None,
+            Expires = expiresAt,
+            Path = RefreshCookiePath
         };
 
         Response.Cookies.Append(RefreshCookieName, refreshToken, cookieOptions);

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -23,6 +24,17 @@ var jwtAudience = builder.Configuration["Jwt:Audience"]
 var jwtSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret));
 
 Console.WriteLine("Hello, World!");
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("FrontendCors", policy =>
+    {
+        policy.WithOrigins(allowedOrigins)
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+});
 
 // TESTING THE RULES
 
@@ -126,17 +138,6 @@ builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 builder.Services.AddScoped<AppSeedService>();
 
-var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
-builder.Services.AddCors(options =>
-{
-    options.AddPolicy("FrontendCors", policy =>
-    {
-        policy.WithOrigins(allowedOrigins)
-            .AllowAnyHeader()
-            .AllowAnyMethod()
-            .AllowCredentials();
-    });
-});
 
 builder.Services.AddControllers();
 var app = builder.Build();
@@ -160,6 +161,59 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.UseCors("FrontendCors");
+
+var allowedOriginSet = new HashSet<string>(allowedOrigins, StringComparer.OrdinalIgnoreCase);
+app.Use(async (context, next) =>
+{
+    var method = context.Request.Method;
+    var isUnsafeMethod = !(HttpMethods.IsGet(method) || HttpMethods.IsHead(method) || HttpMethods.IsOptions(method));
+
+    if (!isUnsafeMethod)
+    {
+        await next();
+        return;
+    }
+
+    var path = context.Request.Path.Value ?? string.Empty;
+    var isAuthCookieEndpoint =
+        path.Equals("/api/auth/refresh", StringComparison.OrdinalIgnoreCase) ||
+        path.Equals("/api/auth/logout", StringComparison.OrdinalIgnoreCase);
+
+    if (!isAuthCookieEndpoint)
+    {
+        await next();
+        return;
+    }
+
+    var origin = context.Request.Headers.Origin.ToString();
+    if (!string.IsNullOrWhiteSpace(origin))
+    {
+        if (!allowedOriginSet.Contains(origin))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("CSRF blocked: invalid Origin.");
+            return;
+        }
+
+        await next();
+        return;
+    }
+
+    var referer = context.Request.Headers.Referer.ToString();
+    var refererAllowed = !string.IsNullOrWhiteSpace(referer) &&
+                         allowedOrigins.Any(allowed =>
+                             referer.StartsWith(allowed, StringComparison.OrdinalIgnoreCase));
+
+    if (!refererAllowed)
+    {
+        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+        await context.Response.WriteAsync("CSRF blocked: missing/invalid Referer.");
+        return;
+    }
+
+    await next();
+});
+
 app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();


### PR DESCRIPTION
Introduce RefreshCookiePath and ensure cookie deletion/appending use the same Path. Configure refresh cookie to be Secure, SameSite=None and have an explicit Path so it works for cross-site authenticated requests. Centralize CORS policy creation (allowed origins from config) and add middleware that enforces Origin/Referer checks for unsafe auth endpoints (/api/auth/refresh, /api/auth/logout), returning 403 on invalid or missing origin/referer to mitigate CSRF. Also add required Http namespace and remove the duplicated CORS registration.