### PR TITLE
Add endpoints for org/user management and user creation DTO

### DIFF
--- a/Controllers/OrganizationController.cs
+++ b/Controllers/OrganizationController.cs
@@ -31,6 +31,28 @@ public class OrganizationController(RiskManagementDbContext context, ICurrentUse
         return Ok(organization);
     }
 
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetOrganizationById(int id)
+    {
+        var role = currentUserService.GetRequiredRole();
+        var currentOrgId = currentUserService.GetRequiredOrganizationId();
+
+        // Only Superadmin has full access
+        if (!IsSuperadmin(role) && id != currentOrgId)
+        {
+            return Forbid();
+        }
+
+        var organization = await context.Organizations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == id);
+
+        if (organization is null)
+            return NotFound();
+
+        return Ok(organization);
+    }
+
     [HttpPost]
     [Authorize(Policy = "SuperadminOnly")]
     public async Task<ActionResult<Organization>> AddOrganization([FromBody] RiskManagement.Dtos.Organization.CreateOrganizationRequest request)

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -16,7 +16,7 @@ public class UserController(
     IPasswordService passwordService) : ControllerBase
 {
     [HttpGet]
-    [Authorize(Policy = "AdminOrSuperadmin")]
+   
     public async Task<ActionResult<List<UserResponse>>> GetUsers()
     {
         var role = currentUserService.GetRequiredRole();
@@ -121,6 +121,48 @@ public class UserController(
         return Ok(user);
     }
 
+    [HttpPost]
+    [Authorize(Policy = "SuperadminOnly")]
+    public async Task<ActionResult<UserResponse>> CreateUser([FromBody] CreateUserRequest request)
+    {
+        // Prevent creating Superadmins
+        if (request.Role.Equals("Superadmin", StringComparison.OrdinalIgnoreCase))
+        {
+            return BadRequest("Creating Superadmin users is not allowed.");
+        }
+
+        var normalizedEmail = request.Email.Trim().ToLowerInvariant();
+
+        var emailExists = await context.Users
+            .AnyAsync(x => x.Email == normalizedEmail);
+
+        if (emailExists)
+        {
+            return Conflict("Email already exists.");
+        }
+
+        var now = DateTime.UtcNow;
+
+        var user = new User
+        {
+            FirstName = request.FirstName.Trim(),
+            LastName = request.LastName.Trim(),
+            Email = normalizedEmail,
+            Role = request.Role,
+            Status = request.Status,
+            OrganizationId = request.OrganizationId,
+            CreatedAt = now,
+            UpdatedAt = now,
+            PasswordHash = ""
+        };
+
+        user.PasswordHash = passwordService.HashPassword(user, request.Password);
+
+        context.Users.Add(user);
+        await context.SaveChangesAsync();
+
+        return Ok(Map(user));
+    }
     [HttpPut("{id:int}")]
     public async Task<ActionResult<UserResponse>> UpdateUser(int id, [FromBody] UpdateUserRequest request)
     {

--- a/Dtos/User/CreateUserRequest.cs
+++ b/Dtos/User/CreateUserRequest.cs
@@ -1,0 +1,36 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace RiskManagement.Dtos.User;
+
+public class CreateUserRequest
+{
+    [Required]
+    [MinLength(2)]
+    [MaxLength(100)]
+    public string FirstName { get; set; } = string.Empty;
+
+    [Required]
+    [MinLength(2)]
+    [MaxLength(100)]
+    public string LastName { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    [MaxLength(255)]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [MinLength(8)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required]
+    [RegularExpression("^(User|Admin|Superadmin)$")]
+    public string Role { get; set; } = "User";
+
+    [Required]
+    [RegularExpression("^(Active|Inactive)$")]
+    public string Status { get; set; } = "Active";
+
+    [Required]
+    public int OrganizationId { get; set; }
+}


### PR DESCRIPTION
Added GET endpoint to fetch organization by ID with access control. Introduced POST endpoint for Superadmin to create users, with validation to prevent Superadmin creation and duplicate emails. Created CreateUserRequest DTO with validation attributes for user creation. Removed restrictive authorization from GetUsers.