### PR TITLE
Clean up comments, logging, and config usage

### DIFF
--- a/Controllers/ActionPlanController.cs
+++ b/Controllers/ActionPlanController.cs
@@ -12,8 +12,6 @@ namespace RiskManagement.Controllers;
 [Authorize]
 public class ActionPlanController(RiskManagementDbContext context, ICurrentUserService currentUserService) : ControllerBase
 {
-
-    // GET: api/ActionPlan
     [HttpGet]
 
     public async Task<ActionResult<List<ActionPlanResponse>>> GetAll()
@@ -43,7 +41,6 @@ public class ActionPlanController(RiskManagementDbContext context, ICurrentUserS
         return Ok(actionPlans);
     }
 
-    // GET: api/ActionPlan/5
     [HttpGet("{id}")]
 
     public async Task<ActionResult<ActionPlanResponse>> Get(int id)
@@ -74,7 +71,6 @@ public class ActionPlanController(RiskManagementDbContext context, ICurrentUserS
         return Ok(actionPlan);
     }
 
-    // POST: api/ActionPlan
     [HttpPost]
     [Authorize(Policy = "AdminOrSuperadmin")]
     public async Task<ActionResult<ActionPlanResponse>> Create([FromBody] CreateActionPlanRequest createDto)
@@ -86,7 +82,6 @@ public class ActionPlanController(RiskManagementDbContext context, ICurrentUserS
         if (createDto.RiskId == 0) createDto.RiskId = null;
         if (createDto.IncidentId == 0) createDto.IncidentId = null;
 
-        // XOR validation
         if (createDto.RiskId.HasValue == createDto.IncidentId.HasValue)
         {
             return BadRequest("Provide either RiskId OR IncidentId (exactly one required).");
@@ -147,7 +142,6 @@ public class ActionPlanController(RiskManagementDbContext context, ICurrentUserS
         return CreatedAtAction(nameof(Get), new { id = entity.Id }, response);
     }
 
-    // PUT: api/ActionPlan/5
     [HttpPut("{id}")]
     [Authorize(Policy = "AdminOrSuperadmin")]
     public async Task<ActionResult<ActionPlanResponse>> Update(int id, [FromBody] UpdateActionPlanRequest updateDto)
@@ -220,7 +214,7 @@ public class ActionPlanController(RiskManagementDbContext context, ICurrentUserS
         return Ok(response);
     }
 
-    
+
 
     private async Task<int?> ValidateOwnerAsync(int organizationId, int? ownerUserId)
     {

--- a/Controllers/AssetController.cs
+++ b/Controllers/AssetController.cs
@@ -83,7 +83,6 @@ public class AssetController(RiskManagementDbContext context, ICurrentUserServic
 
         var role = currentUserService.GetRequiredRole();
         var currentOrgId = currentUserService.GetRequiredOrganizationId();
-        //Admin cant't send OrganizationId
         if (!IsSuperadmin(role) && request.OrganizationId.HasValue)
         {
             return BadRequest("Only Superadmin can set OrganizationId.");
@@ -157,7 +156,7 @@ public class AssetController(RiskManagementDbContext context, ICurrentUserServic
         return Ok(Map(asset));
     }
 
-    
+
 
     private static bool IsSuperadmin(string role) => role.Equals("Superadmin", StringComparison.OrdinalIgnoreCase);
 

--- a/Controllers/OrganizationController.cs
+++ b/Controllers/OrganizationController.cs
@@ -37,7 +37,6 @@ public class OrganizationController(RiskManagementDbContext context, ICurrentUse
         var role = currentUserService.GetRequiredRole();
         var currentOrgId = currentUserService.GetRequiredOrganizationId();
 
-        // Only Superadmin has full access
         if (!IsSuperadmin(role) && id != currentOrgId)
         {
             return Forbid();
@@ -96,7 +95,7 @@ public class OrganizationController(RiskManagementDbContext context, ICurrentUse
         return Ok(org);
     }
 
-   
+
 
     [HttpPut("{id:int}/audit-details")]
     public async Task<IActionResult> UpdateAuditDetails(int id, [FromBody] RiskManagement.Dtos.Organization.AuditDetailsRequest request)
@@ -104,7 +103,6 @@ public class OrganizationController(RiskManagementDbContext context, ICurrentUse
         var role = currentUserService.GetRequiredRole();
         var currentOrgId = currentUserService.GetRequiredOrganizationId();
 
-        // Only Superadmin or Admin can update audit details
         var isAdmin = role.Equals("Admin", StringComparison.OrdinalIgnoreCase);
         var isSuperadmin = IsSuperadmin(role);
 
@@ -143,7 +141,6 @@ public class OrganizationController(RiskManagementDbContext context, ICurrentUse
         var role = currentUserService.GetRequiredRole();
         var currentOrgId = currentUserService.GetRequiredOrganizationId();
 
-        // Only Superadmin has full access, others can only view their own organization
         if (!IsSuperadmin(role) && id != currentOrgId)
         {
             return Forbid();

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -16,7 +16,7 @@ public class UserController(
     IPasswordService passwordService) : ControllerBase
 {
     [HttpGet]
-   
+
     public async Task<ActionResult<List<UserResponse>>> GetUsers()
     {
         var role = currentUserService.GetRequiredRole();
@@ -121,7 +121,7 @@ public class UserController(
         return Ok(user);
     }
 
-   
+
     [HttpPut("{id:int}")]
     public async Task<ActionResult<UserResponse>> UpdateUser(int id, [FromBody] UpdateUserRequest request)
     {
@@ -150,12 +150,10 @@ public class UserController(
         {
             return Forbid();
         }
-        // Prevent Admin & Superadmin from changing their own role
         if (!string.IsNullOrWhiteSpace(request.Role) && id == currentUserId)
         {
             return BadRequest("You cannot change your own role.");
         }
-        // Only Superadmin can assign Superadmin role
         if (!string.IsNullOrWhiteSpace(request.Role) &&
             request.Role.Equals("Superadmin", StringComparison.OrdinalIgnoreCase) &&
             !IsSuperadmin(role))
@@ -241,7 +239,7 @@ public class UserController(
         return Ok(Map(user));
     }
 
-   
+
 
     private static bool IsSuperadmin(string role) => role.Equals("Superadmin", StringComparison.OrdinalIgnoreCase);
     private static bool IsUser(string role) => role.Equals("User", StringComparison.OrdinalIgnoreCase);

--- a/Models/Asset.cs
+++ b/Models/Asset.cs
@@ -5,7 +5,7 @@ namespace RiskManagement.Models
         public int Id { get; set; }
 
         public int OrganizationId { get; set; }
-       
+
 
         public required string Name { get; set; } = null!;
 
@@ -21,9 +21,7 @@ namespace RiskManagement.Models
 
         public DateTime UpdatedAt { get; set; }
 
-        // Navigation property
-
-        public  Organization Organization { get; set; } = null!;
+        public Organization Organization { get; set; } = null!;
         public List<Risk> Risks { get; set; } = [];
 
     }

--- a/Program.cs
+++ b/Program.cs
@@ -23,7 +23,6 @@ var jwtAudience = builder.Configuration["Jwt:Audience"]
 
 var jwtSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret));
 
-Console.WriteLine("Hello, World!");
 var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
 builder.Services.AddCors(options =>
 {
@@ -36,10 +35,6 @@ builder.Services.AddCors(options =>
     });
 });
 
-// TESTING THE RULES
-
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
 builder.Services.AddSwaggerGen(options =>
 {
@@ -72,9 +67,9 @@ builder.Services.AddDbContext<RiskManagementDbContext>(options =>
 
     options.UseMySql(
 
-        builder.Configuration.GetConnectionString("DefaultConnection"),
+        defaultConnection,
 
-        ServerVersion.AutoDetect(builder.Configuration.GetConnectionString("DefaultConnection"))
+        ServerVersion.AutoDetect(defaultConnection)
 
     ));
 
@@ -92,24 +87,6 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidAudience = jwtAudience,
             IssuerSigningKey = jwtSigningKey,
             ClockSkew = TimeSpan.Zero
-        };
-
-        options.Events = new JwtBearerEvents
-        {
-            OnAuthenticationFailed = context =>
-            {
-                Console.WriteLine($"JWT authentication failed: {context.Exception.Message}");
-                return Task.CompletedTask;
-            },
-            OnChallenge = context =>
-            {
-                if (!string.IsNullOrWhiteSpace(context.ErrorDescription))
-                {
-                    Console.WriteLine($"JWT challenge error: {context.ErrorDescription}");
-                }
-
-                return Task.CompletedTask;
-            }
         };
     });
 
@@ -149,7 +126,6 @@ using (var scope = app.Services.CreateScope())
 }
 
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();


### PR DESCRIPTION
Remove extraneous inline comments and whitespace across controllers, tidy up Asset model formatting, and eliminate debug logging and JWT event handlers from Program.cs. Replace direct GetConnectionString usage with the defaultConnection variable and use it for ServerVersion.AutoDetect. Overall cleanup to reduce noise and centralize configuration usage.